### PR TITLE
Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@
 name: Multi-arch and multi-distro build for sriov-network-* container images
 on:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 


### PR DESCRIPTION
Add the [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) trigger to the GitHub Action flow, in order to be able to manually trigger it from the main branch.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>