### PR TITLE
Extend matrix for config-daemon and webhook images

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        container: [ operator ]
+        container: [ operator, config-daemon, webhook ]
         distro-name: [ centos-stream ]
         distro-version: [ 9 ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change adds the config-daemon and webhook to the workflow matrix,
dynamically creating new jobs for CentOS Stream 9.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>