### PR TITLE
Update README to remove mentions of UBI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Build files for sriov-network-operator on UBI
+# Build files for sriov-network-operator
 
-This repository contains the build tools to base sriov-network-operator images on UBI base images.
+This repository contains the build tools to base sriov-network-operator images on various base images.
 This allows us to setup nightly builds based on the upstream repository, without adding more complexity in the upstream repository.


### PR DESCRIPTION
The repository is used to build on top of other images than UBI. This
change reflects that in the README file.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>