### PR TITLE
Restrict image push to avoid errors on pull requests

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,12 +1,13 @@
-# Workflow that performs daily builds of k8snetworkplumbingwg/sriov-network-operator
-# The images are based on CentOS 8, CentOS Stream 9, Fedora and Red Hat UBI
+# Workflow that performs builds of k8snetworkplumbingwg/sriov-network-operator images
+# The images are also pushed to quay.io if it's not a pull request
 
 name: Multi-arch and multi-distro build for sriov-network-* container images
 on:
   pull_request:
-  workflow_dispatch:
+  push:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
+  workflow_dispatch:
 
 jobs:
   build:
@@ -38,6 +39,12 @@ jobs:
 
       - name: Push the ${{ matrix.container }} image for ${{ matrix.distro-name }}-${{ matrix.distro-version }} to Quay.io
         id: push-to-quay
+        if: |
+          github.event_name == 'schedule' ||
+          (
+            ( github.event_name == 'push' || github.event_name == 'workflow_dispatch' ) &&
+            ( github.ref == 'refs/head/main' || startsWith(github.ref, 'refs/head/release' ))
+          )
         uses: redhat-actions/push-to-registry@v2
         with:
           image: sriov-network-${{ matrix.container }}
@@ -46,5 +53,3 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Print image url
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"


### PR DESCRIPTION
According to [GitHub Action > Using encrypted secrets in a workflow](https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow), secrets are not passed to the runner when a workflow is triggered from a forked repository. This means that pull requests will not be able to leverage the secrets to push images to the registry.

With this pull request, the push should be only performed in the following cases:

- the pull request is merged to the main or release branches,
- the workflow is manually triggered from the main or release branches,
- the scheduled time is reached.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>