### PR TITLE
Add workflow step to lint Dockerfiles

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,6 +21,13 @@ jobs:
       - name: Checkout current repository for the Dockerfiles
         uses: actions/checkout@v2
 
+      - name: Lint Dockerfile
+        if: github.event_name == 'pull_request'
+        uses: hadolint/hadolint-action@v1.6.0
+        with:
+          dockerfile: ${{ matrix.distro-name }}/${{ matrix.distro-version }}/Dockerfile.${{ matrix.container }}
+          failure-threshold: error
+
       - name: Checkout k8snetworkplumbingwg/sriov-network-operator for the code
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pr-build-images.yaml
+++ b/.github/workflows/pr-build-images.yaml
@@ -1,0 +1,12 @@
+name: Multi-arch and multi-distro build for sriov-network-* container images
+on:
+  pull_request:
+
+jobs:
+  build-images:
+    strategy:
+      matrix:
+        container: [ operator, config-daemon, webhook ]
+        distro-name: [ centos-stream ]
+        distro-version: [ 9 ]
+    uses: ./.github/workflows/wf-build-image.yaml


### PR DESCRIPTION
The repository contains only Dockerfiles for the various distributions,
so we enable GitHub's SuperLinter to check their syntax. Each job
generated by the matrix will lint only the files relevant to its
distribution.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>